### PR TITLE
Update plot.py

### DIFF
--- a/python/paddle/utils/plot.py
+++ b/python/paddle/utils/plot.py
@@ -107,8 +107,10 @@ class Ploter(object):
             self.display.display(self.plt.gcf())
         else:
             self.plt.savefig(path)
-        self.plt.gcf().clear()
 
+    def close_plot(self):
+        self.plt.gcf().clear()
+        
     def reset(self):
         for key in self.__plot_data__:
             data = self.__plot_data__[key]


### PR DESCRIPTION
clear()函数会清空Figure对象，导致在Jupyter Notebook中不能显示绘图（尤其是在AIStudio里的Jupyter Notebook），我们可以显示的调用close_plot()这样的函数来清除Figure对象，释放内存。